### PR TITLE
Suggest Component Story Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,23 @@ import { h } from 'preact';
 import {storiesOf} from '@storybook/preact';
 import {withAmp} from '@ampproject/storybook-addon';
 
-storiesOf('amp-carousel', module)
-  .addDecorator(withAmp)
-  .addParameters({
-    extensions: [{name: 'amp-carousel', version: '0.2'}],
-  })
-  .add('default', () => {
-    return (
-      <amp-base-carousel width="440" height="225">
-        {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
-          <div key={color}>{color}</div>
-        ))}
-      </amp-base-carousel>
-    );
-  });
+export default {
+  title: 'amp-carousel',
+  decorators: [withAmp],
+  parameters: {
+    extensions: [{name: 'amp-carousel', version: '0.2'}]},
+  },
+};
+
+export const Default = () => {
+  return (
+    <amp-base-carousel width="440" height="225">
+      {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
+        <div key={color}>{color}</div>
+      ))}
+    </amp-base-carousel>
+  );
+};
 ```
 
 The following parameters can be specified:


### PR DESCRIPTION
From [Storybook's docs](https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md):

> In Storybook 5.2 we introduced a simpler and more portable [Component Story Format](https://storybook.js.org/docs/react/api/csf), and all future tools and infrastructure will be oriented towards CSF. Therefore, we recommend migrating your stories out of `storiesOf` API, and even provide [automated tools to do this](https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md#component-story-format-migration).

Also: https://github.com/ampproject/amphtml/pull/30329