### PR TITLE
Support 3p iframe addressing in the local mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/storybook-addon",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Storybook addon for building and testing AMP components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/register/components/PreactDecorator.tsx
+++ b/src/register/components/PreactDecorator.tsx
@@ -75,6 +75,7 @@ export const Decorator: StoryWrapper = (getStory, context, { parameters }) => {
             <title>AMP Page Example</title>
             <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
             ${getBase(config)}
+            ${get3pIframeMeta(config)}
             ${
               context?.parameters?.experiments?.length > 0 ?
               `<script>
@@ -153,6 +154,15 @@ function getBase(config: Config): string {
     return "";
   }
   return `<base href="${new URL(config.baseUrl).origin}">`;
+}
+
+function get3pIframeMeta(config: Config): string {
+  if (!config.baseUrl.startsWith("http://localhost")) {
+    return "";
+  }
+  const baseUrl3p = config.baseUrl.replace('//localhost', '//ads.localhost');
+  const src3p = new URL('/dist.3p/current/frame.max.html', baseUrl3p).href;
+  return `<meta name="amp-3p-iframe-src" content="${src3p}">`;
 }
 
 function getAmpUrl(

--- a/test/base-carousel-1.0.stories.js
+++ b/test/base-carousel-1.0.stories.js
@@ -25,7 +25,7 @@ storiesOf('amp-base-carousel-1.0', module)
   .addDecorator(withAmp)
   .addParameters({
     extensions: [{name: 'amp-base-carousel', version: '1.0'}],
-    experiments: ['amp-base-carousel-bento'],
+    experiments: ['bento'],
   })
   .add('default', () => {
     const slide1 = text('slide1', 'lightcoral');


### PR DESCRIPTION
Includes `<meta name="amp-3p-iframe-src">` in the local mode to address 3p iframe correctly.