### PR TITLE
✨ Generate amp-script-src hashes

### DIFF
--- a/src/register/components/PreactDecorator.tsx
+++ b/src/register/components/PreactDecorator.tsx
@@ -24,6 +24,7 @@ import addons, { StoryWrapper } from "@storybook/addons";
 import { Events } from "../../addon";
 import { SOURCE_BASE_URL, Config, defaultConfig, sameConfig } from "./config";
 import { useBentoMode } from "./bento";
+import { collectInlineAmpScripts, maybeGenerateCspHashMeta } from "../../util/amp-script";
 
 const EXT_TYPES = {
   'amp-mustache': 'template',
@@ -49,7 +50,11 @@ export const Decorator: StoryWrapper = (getStory, context, { parameters }) => {
     };
   }, []);
 
-  const contents = preactRenderToString(getStory(context));
+  const storyTree = getStory(context);
+
+  const inlineScripts = collectInlineAmpScripts(storyTree);
+
+  const contents = preactRenderToString(storyTree);
   const styleElements = flush();
   const styles = preactRenderToString(
     <style
@@ -74,6 +79,7 @@ export const Decorator: StoryWrapper = (getStory, context, { parameters }) => {
             <meta charSet="utf-8" />
             <title>AMP Page Example</title>
             <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
+            ${maybeGenerateCspHashMeta(inlineScripts)}
             ${getBase(config)}
             ${get3pIframeMeta(config)}
             ${

--- a/src/util/amp-script.ts
+++ b/src/util/amp-script.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createHash } from "crypto";
+
+const hash = createHash("sha384");
+
+export function generateCspHash(script) {
+  const data = hash.update(script, "utf8");
+
+  return (
+    "sha384-" +
+    data
+      .digest("base64")
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+  );
+}
+
+export function collectInlineAmpScripts(tree) {
+  let scripts: string[] = [];
+  for (const child of tree?.props?.children ?? []) {
+    if (
+      child.type === "script" &&
+      child.props?.target === "amp-script" &&
+      typeof child.props?.children === "string"
+    ) {
+      scripts.push(child.props.children);
+    } else {
+      scripts = [...scripts, ...collectInlineAmpScripts(child)];
+    }
+  }
+  return scripts;
+}
+
+export function maybeGenerateCspHashMeta(scripts) {
+  if (scripts.length < 1) {
+    return "";
+  }
+  return `<meta name="amp-script-src" content="${scripts
+    .map((script) => generateCspHash(script))
+    .join(" ")}" />`;
+}

--- a/test/amp-script-0.1.stories.js
+++ b/test/amp-script-0.1.stories.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @jsx h */
+import { h } from "preact";
+import { storiesOf } from "@storybook/preact";
+import { withAmp } from "../esm";
+import { text, withKnobs } from "@storybook/addon-knobs";
+
+storiesOf("amp-script-0.1", module)
+  .addDecorator(withKnobs)
+  .addDecorator(withAmp)
+  .addParameters({
+    extensions: [{ name: "amp-script", version: "0.1" }],
+  })
+  .add("amp-script", () => (
+    <div>
+      Open console, see "amp-script executed".
+      <amp-script id="dataFunctions" script="local-script" nodom></amp-script>
+      <script id="local-script" type="text/plain" target="amp-script">
+        {`
+        console.log('amp-script executed');
+        `}
+      </script>
+    </div>
+  ));


### PR DESCRIPTION
Generates and embeds a [script hash](https://amp.dev/documentation/components/amp-script/#calculating-the-script-hash) for every inline script found in a story.
