### PR TITLE
🐛 Don't reuse hash object

### DIFF
--- a/src/util/amp-script.ts
+++ b/src/util/amp-script.ts
@@ -16,9 +16,8 @@
 
 import { createHash } from "crypto";
 
-const hash = createHash("sha384");
-
 export function generateCspHash(script) {
+  const hash = createHash("sha384");
   const data = hash.update(script, "utf8");
 
   return (


### PR DESCRIPTION
Reusing the hash object doesn't seem to play well.
A [documentation](https://amp.dev/documentation/components/amp-script/#calculating-the-script-hash) change for `amp-script` might be in order, since it reuses the object.